### PR TITLE
anchor size to 8 and use score_thre=0.60 for scouting feed

### DIFF
--- a/configs/_base_/models/cascade_rcnn_r50_fpn_anchor.py
+++ b/configs/_base_/models/cascade_rcnn_r50_fpn_anchor.py
@@ -26,7 +26,7 @@ model = dict(
             # scales=[8],
             # ratios=[0.5, 1.0, 2.0],
             # strides=[4, 8, 16, 32, 64]),
-            scales=[5.5],
+            scales=[8],
             ratios=[0.5, 1.0, 2.0],
             strides=[4, 8, 16, 32]),
         bbox_coder=dict(
@@ -182,6 +182,6 @@ test_cfg = dict(
         nms_thr=0.7,
         min_bbox_size=0),
     rcnn=dict(
-        score_thr=0.70,
+        score_thr=0.60,
         nms=dict(type='nms', iou_threshold=0.10),
         max_per_img=100))


### PR DESCRIPTION
config changes for scouting feed.

1. with small anchor size (5.5), it doesn't detect new annotated field which was trained with anchor size (8).

2. small adjustment for score threshold